### PR TITLE
Fix for RasPlex issue

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -140,6 +140,8 @@ def ListItems(group):
         # Simply adding VideoClipObject does not work on some clients (like LG SmartTV),
         # so there is an endless recursion - function CreateVideoClipObject calling itself -
         # and I have no idea why and how it works...
+        if not summary:
+                summary = item['title']
         oc.add(CreateVideoClipObject(
             url = item['url'],
             title = item['title'],


### PR DESCRIPTION
In case summary data is empty, UI of RasPlex will disappear, making it
impossible for user to play a channel. Fix puts channel title in
summary field if empty. Tested and it works fine.