### PR TITLE
Fix HTTP routing if 'summary' field is missing (required for Chromecast)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -175,7 +175,7 @@ def ListItems(group):
     return oc
 
 @route(PREFIX + '/createvideoclipobject')
-def CreateVideoClipObject(url, title, thumb, summary, container = False):
+def CreateVideoClipObject(url, title, thumb, summary = None, container = False):
     vco = VideoClipObject(
         key = Callback(CreateVideoClipObject, url = url, title = title, thumb = thumb, summary = summary, container = True),
         rating_key = title,


### PR DESCRIPTION
Hi, i did this small fix to make the plugin work correctly with Chromecast (at least with my streaming sources).
Because Chromecast doesn't send the "summary" field i made it optional (with None as default value) so Plex can handle the route also without this field.
