### PR TITLE
Add guide_offset_seconds and guide_format_string options

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -416,10 +416,21 @@ def GetSummary(id, name, title, default = ''):
                     guide_hours = 8
                 for item in items_list:
                     if item['start'] <= current_datetime + Datetime.Delta(hours = guide_hours) and item['stop'] > current_datetime:
+                        try:
+                            guide_offset_seconds = int(Prefs['guide_offset_seconds'])
+                        except:
+                            guide_offset_seconds = 0
+
+                        try:
+                            guide_format_string = Prefs['guide_format_string']
+                        except:
+                            guide_format_string = '%H:%M'
+
+                        start = (item['start'] + Datetime.Delta(seconds = guide_offset_seconds)).strftime(guide_format_string)
                         if summary:
-                            summary = summary + '\n' + item['start'].strftime('%H:%M') + ' ' + item['title']
+                            summary = summary + '\n' + start + ': ' + item['title']
                         else:
-                            summary = item['start'].strftime('%H:%M') + ' ' + item['title']
+                            summary = start + ': ' + item['title']
                         if item['desc']:
                             summary = summary + ' - ' + item['desc']
 

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -12,6 +12,18 @@
         "default":  ""
     },
     {
+        "id":       "guide_offset_seconds",
+        "label":    "Number of seconds by which to offset the XMLTV guide start time",
+        "type":     "text",
+        "default":  "0"
+    },
+    {
+        "id":       "guide_format_string",
+        "label":    "Format string to use for displaying times",
+        "type":     "text",
+        "default":  "%H:%M"
+    },
+    {
         "id":       "images_path",
         "label":    "Local path (experimental) or URL where images are located, if left empty images will be loaded from Resources folder",
         "type":     "text",


### PR DESCRIPTION
Some guides need to be offset by a second in order to display a start
time on the half hour.

Some people might want a different format string that the default 24
hour time.