### PR TITLE
improve search, add guide offset, expose guide format string

### DIFF
--- a/Contents/Code/xmltv_parser.py
+++ b/Contents/Code/xmltv_parser.py
@@ -104,6 +104,7 @@ def LoadGuide():
                                 'stop': stop,
                                 'title': title,
                                 'desc': desc,
+                                'channel_id': channel,
                                 'order': count
                             }
                             guide.setdefault(channel, {})[count] = item

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -12,6 +12,18 @@
         "default":  ""
     },
     {
+        "id":       "guide_offset_seconds",
+        "label":    "Number of seconds by which to offset the XMLTV guide start time",
+        "type":     "text",
+        "default":  "0"
+    },
+    {
+        "id":       "guide_format_string",
+        "label":    "Format string to use for displaying times",
+        "type":     "text",
+        "default":  "%H:%M"
+    },
+    {
         "id":       "images_path",
         "label":    "Local path (experimental) or URL where images are located, if left empty images will be loaded from Resources folder",
         "type":     "text",


### PR DESCRIPTION
Allow searching within program titles

Some guides need to be offset by a second in order to display a start
time on the half hour.

Some people might want a different format string that the default 24
hour time.